### PR TITLE
PMKSA: Fix use-after-free in pmksa_cache_clone_entry()

### DIFF
--- a/src/rsn_supp/pmksa_cache.c
+++ b/src/rsn_supp/pmksa_cache.c
@@ -345,6 +345,7 @@ pmksa_cache_clone_entry(struct rsn_pmksa_cache *pmksa,
 			const u8 *aa)
 {
 	struct rsn_pmksa_cache_entry *new_entry;
+	os_time_t old_expiration = old_entry->expiration;
 
 	new_entry = pmksa_cache_add(pmksa, old_entry->pmk, old_entry->pmk_len,
 				    NULL, NULL, 0,
@@ -354,7 +355,7 @@ pmksa_cache_clone_entry(struct rsn_pmksa_cache *pmksa,
 		return NULL;
 
 	/* TODO: reorder entries based on expiration time? */
-	new_entry->expiration = old_entry->expiration;
+	new_entry->expiration = old_expiration;
 	new_entry->opportunistic = 1;
 
 	return new_entry;


### PR DESCRIPTION
pmksa_cache_add_entry() may actually free old_entry if the PMKSA cache
is full. This can result in the PMKSA cache containing entries with
corrupt expiration times.

Change-Id: Ibfc5d285eb4ae8efe4ccdf29f34e484485604778
Signed-off-by: Andrew Elble <aweits@rit.edu>